### PR TITLE
Readjusted routing and removed summary page

### DIFF
--- a/whatsForLunch/app/views/users/_healthy.html.erb
+++ b/whatsForLunch/app/views/users/_healthy.html.erb
@@ -4,7 +4,7 @@
 	<span style="color: grey; font-size: 20px">Question 5/6:</span>
 	<br/>
 	<div class="animated flipInX">
-		Do you even lift bro?
+		Do you even lift, bro?
 	</div>
 </div>
 <ul class="answer">

--- a/whatsForLunch/app/views/users/_locationRestriction.html.erb
+++ b/whatsForLunch/app/views/users/_locationRestriction.html.erb
@@ -3,7 +3,7 @@
 	<br/><br/>
 	<span style="color: grey; font-size: 20px">Question 1/6:</span><br/>
 	<div class="animated flipInX">
-		Any dietary restriction?
+		Any dietary restrictions?
 	</div>
 	<ul>
 		<li>

--- a/whatsForLunch/app/views/users/_result.html.erb
+++ b/whatsForLunch/app/views/users/_result.html.erb
@@ -1,9 +1,0 @@
-<div class="magic openDownLeft">
-	<div id="summary-title">Well, this is your life decision:</div> 
-	<div id="summary">
-		<%= @mood %><%= @weather %><%= @healthy %><%= @spicy %><%= @price %><%= @restriction %>
-	</div>
-</div>
-
-<!-- Hidden field get location -->
-<%= link_to "NOW LET'S GET SOME GRUB", choiceForToday_path, class: 'sweep-to-right', :method => :post, remote: true %><br />

--- a/whatsForLunch/app/views/users/_weather.html.erb
+++ b/whatsForLunch/app/views/users/_weather.html.erb
@@ -8,7 +8,7 @@
 <ul class="answer">
 	<li class="two-choices">
 		<img src="/assets/hot.svg" width="50">
-		<%= link_to "Sweaty weather", questionSpicy_path(:weather => true), id: 'two-choices', :method => :post, remote: true %>
+		<%= link_to "Sweaty", questionSpicy_path(:weather => true), id: 'two-choices', :method => :post, remote: true %>
 	</li>
 	<li class="two-choices">
 		<img src="/assets/cold.svg" width="50">

--- a/whatsForLunch/app/views/users/index.html.erb
+++ b/whatsForLunch/app/views/users/index.html.erb
@@ -1,4 +1,4 @@
 <div class="question">
-	<%= link_to "FIND ME A PLACE TO EAT", getLocation_path, method: :post, id: 'start_btnz', remote: true %><br /><br />
+	<%= link_to "GET ME FED", getLocation_path, method: :post, id: 'start_btnz', remote: true %><br /><br />
 	<img id="yelp-logo" style="margin-top: 10px" src="/assets/yelp_logo.png" width="50">
 </div>

--- a/whatsForLunch/app/views/users/result.js.erb
+++ b/whatsForLunch/app/views/users/result.js.erb
@@ -1,1 +1,0 @@
-$(".question").html('<%= j render("result") %>')

--- a/whatsForLunch/config/routes.rb
+++ b/whatsForLunch/config/routes.rb
@@ -6,11 +6,9 @@ Rails.application.routes.draw do
   post 'questions/5' => "users#fifth_spicy", as: :questionSpicy
   post 'questions/6' => "users#sixth_healthy", as: :questionHealthy
   post 'questions/7' => "users#seventh_price", as: :questionPrice
-  post 'result' => "users#result", as: :result
-  post 'choice_for_today' => "users#choice_for_today", as: :choiceForToday 
-  # post 'search' => 'users#search', as: :search
-  # get 'result' => "users#show", as: :whatsForLunch
-  resources :users
+  post 'result' => "users#show", as: :result
+  get 'search' => 'users#search', as: :search
+  #get 'result' => "users#show", as: :whatsForLunch
 
   root 'users#index'
 


### PR DESCRIPTION
I returned it to the routing I set up yesterday. We didn't need the users: resources set of routes since you two were so specific in setting up the partials, and I got rid of choiceForToday and the associated pages, since they weren't included in our intended UX and were there, I think, as placeholders.

The final submission is now the price, which leads straight to the show page.  See previous push for the status on that.
